### PR TITLE
Remove link to Red Cross donation

### DIFF
--- a/public/censorship/index.html
+++ b/public/censorship/index.html
@@ -66,7 +66,6 @@
   <br>
   <li>For Twitter profiles, since PussTheCat.org is affected by this ban, our Nitter instance can't display the content. I personally recommend <a class="text-muted word-wrap" href="https://nitter.kavin.rocks/">nitter.kavin.rocks</a> (based in India).</li>
 </ul>
-PS: If you can, donate to the <a class="text-muted word-wrap" href="https://donate.redcrossredcrescent.org/ua/donate/~my-donation">Ukraine Red Cross</a>
 <br><br><br>
 <p>Signed: TheFrenchGhosty, founder of PussTheCat.org</p>
 </div>


### PR DESCRIPTION
Removed Red Cross donation link, as they spending money in a terrible way.
Sources:
https://mobile.twitter.com/your_psychoo/status/1507110118906863617?s=21&t=8Wz67Xfp19a3lT6r0VaIwg
https://life.pravda.com.ua/society/2022/03/26/247987/
https://telegraf.com.ua/ukr/ukraina/2022-03-25/5700516-na-krasnom-kreste-mozhno-stavit-krest-ukraintsev-vozmutili-strannye-dogovorennosti-s-lavrovym
https://nv.ua/ukr/ukraine/events/chervoniy-hrest-skandal-z-ofisom-u-rostovi-nacionalniy-komitet-poyasniv-situaciyu-novini-ukrajini-50228742.html

If you want to support Ukraine (which is great), use different donation method - The Return Alive Foundation ( https://savelife.in.ua/en/donate/ or https://www.comebackalive.in.ua/donate ), for example.